### PR TITLE
Old style exceptions are syntax errors in Python 3

### DIFF
--- a/components/koDBConnOracle.py
+++ b/components/koDBConnOracle.py
@@ -20,14 +20,14 @@ log.setLevel(logging.INFO)
 
 try:
     import dbxlib
-except ImportError, ex:
+except ImportError as ex:
     sys.stderr.write("Failed to load dbxlib: %s\n" % (ex,))
     raise
 
 try:
     import dbx_oracledb
     loaded = True
-except ImportError, ex:
+except ImportError as ex:
     sys.stderr.write("Failed to load dbx_oracledb: %s\n" % (ex,))
     loaded = False
 
@@ -105,7 +105,7 @@ class KoOracleDBXConnection(dbxlib.KoDBXConnection):
             names = sorted(table_names,
                            key=lambda item:item[0].lower())
             return names
-        except Exception, ex:
+        except Exception as ex:
             log.exception("Failed: KoOracleDBXConnection.getChildren")
             return [("Error: " + str(ex), 'error', None)]
 
@@ -140,7 +140,7 @@ class KoOracle_DBXDatabase(dbxlib.KoDBXConnectionChild):
             table_names = [(name, 'table', KoOracle_DBXTable(self, name)) for name in db.listAllTableNames()]
             names = sorted(table_names, key=lambda item:item[0].lower())
             return names
-        except Exception, ex:
+        except Exception as ex:
             log.exception("Failed: KoOracle_DBXDatabase.getChildren")
             return [("Error: " + str(ex), 'error', None)]
         
@@ -178,7 +178,7 @@ class KoOracle_DBXTable(dbxlib.KoDBXConnectionChild,KoOracleDBXTableConnection):
             column_names = [(name, 'column', KoOracle_DBXColumn(self, name)) for name in db.listAllColumnNames(self._dbname, self._table_name)]
             names = sorted(column_names, key=lambda item:item[0].lower())
             return names
-        except Exception, ex:
+        except Exception as ex:
             log.exception("Failed: KoOracleDBXConnection.getChildren")
             return [("Error: " + str(ex), 'error')]
 

--- a/pylib/dbx_oracledb.py
+++ b/pylib/dbx_oracledb.py
@@ -20,7 +20,7 @@ try:
     import cx_Oracle
     loaded = True
     disabled_reason = None
-except ImportError, ex:
+except ImportError as ex:
     sys.stderr.write("**************** Couldn't load cx_Oracle: %s\n" % (ex,))
     import missingAdaptor
     cx_Oracle = missingAdaptor.MissingAdaptor()
@@ -199,9 +199,9 @@ class Database(dbxlib.CommonDatabase):
                 items = cu.fetchall()
                 names = [row[0] for row in items]
                 return names
-        except NotImplementedError, ex:
+        except NotImplementedError as ex:
             raise OperationalError(ex.message)
-        except Exception, ex:
+        except Exception as ex:
             log.exception("listAllTablePartsByType(typeName:%s)", typeName)
             raise OperationalError(ex.message)
         
@@ -462,10 +462,10 @@ class Database(dbxlib.CommonDatabase):
                 log.debug("insertRowByNamesAndValues: %r", cmd)
                 self.do_query(cu, cmd)
                 res = True
-            except DatabaseError, ex:
+            except DatabaseError as ex:
                 log.exception("dbx_oracledb::insertRowByNamesAndValues: DatabaseError: failed")
                 raise
-            except Exception, ex:
+            except Exception as ex:
                 log.exception("dbx_oracledb::insertRowByNamesAndValues failed")
                 raise
         return res
@@ -487,7 +487,7 @@ class Database(dbxlib.CommonDatabase):
             try:
                 self.do_query(cu, cmd)
                 res = True
-            except Exception, ex:
+            except Exception as ex:
                 log.exception("dbx_oracledb::updateRow failed")
                 res = False
         return res
@@ -503,7 +503,7 @@ class Database(dbxlib.CommonDatabase):
             try:
                 self.do_query(cu, action)
                 res = True
-            except Exception, ex:
+            except Exception as ex:
                 log.exception("dbx_oracledb::executeCustomAction failed")
                 res = False
         return res


### PR DESCRIPTION
New style exceptions work as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/Komodo/Oracle-Database-Explorer on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./pylib/dbx_oracledb.py:23:19: E999 SyntaxError: invalid syntax
except ImportError, ex:
                  ^
./components/koDBConnOracle.py:23:19: E999 SyntaxError: invalid syntax
except ImportError, ex:
                  ^
2     E999 SyntaxError: invalid syntax
2
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.